### PR TITLE
For loop optimization

### DIFF
--- a/lib/rcharts.js
+++ b/lib/rcharts.js
@@ -35,7 +35,7 @@ util.inherits(youtubeResolver, defaultResolver);
 var resolvers = [ new soundCloudResolver(), new youtubeResolver() ];
 
 var getResolverByDomain = function(domain) {
-  for (var i = 0; i < resolvers.length; i++) {
+  for (var i = 0, l = resolvers.length; i < l; i++) {
     if(resolvers[i].domains.indexOf(domain) !== -1) {
       return resolvers[i];
     }


### PR DESCRIPTION
The for loop was not optimized. It was calculating the length of `resolvers` on every iteration of the loop, so I moved it into the first statement, effectively caching the length and preventing this from being unnecessarily called too many times.
